### PR TITLE
修复CocosCreator1.8.2版本Drawcall显示为NaN的问题

### DIFF
--- a/libs/stats/Stats.js
+++ b/libs/stats/Stats.js
@@ -34,7 +34,7 @@ var Stats = function () {
 
     function getDrawcalls() {
         if (window.cc) {
-            return cc.renderer.drawCalls;
+            return cc.g_NumberOfDraws || cc.renderer.drawCalls;
         } else {
             return Infinity;
         }


### PR DESCRIPTION
修复CocosCreator1.8.2版本Drawcall显示为NaN的问题