### PR TITLE
修正调用cc.game.restart后刷新结点树时找不到场景导致的空引用报错

### DIFF
--- a/src/components/TreePanel.vue
+++ b/src/components/TreePanel.vue
@@ -109,10 +109,12 @@ function setChildren(container: TreeNode[], children: any[], path: string[]) {
 
 function refreshTree() {
   // @ts-ignore
-  if (props.show && window.ccdevShow) {
+  const scene = cc.director.getScene();
+  // @ts-ignore
+  if (props.show && window.ccdevShow && scene) {
     let value: TreeNode[] = [];
     //@ts-ignore
-    setChildren(value, cc.director.getScene().children, []);
+    setChildren(value, scene.children, []);
     (treeView.value as any).setData(value);
     updateKey.value = -updateKey.value;
   }


### PR DESCRIPTION
creator3.8.6调用cc.game.restart()后，存在cc.director.getScene()为空的情况，这个pr做了空引用保护